### PR TITLE
Change module include for Rails 4.2

### DIFF
--- a/lib/postgresql/check/schema_definitions.rb
+++ b/lib/postgresql/check/schema_definitions.rb
@@ -2,12 +2,22 @@ module Postgresql
   module Check
     module SchemaDefinitions
       def self.included(base)
-        base::Table.class_eval do
-          include Postgresql::Check::Table
-        end
+        if ActiveRecord::VERSION::STRING > "4.2"
+          ActiveRecord::ConnectionAdapters::PostgreSQL::Table.class_eval do
+            include Postgresql::Check::Table
+          end
 
-        base::TableDefinition.class_eval do
-          include Postgresql::Check::TableDefinition
+          ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition.class_eval do
+            include Postgresql::Check::TableDefinition
+          end
+        else
+          base::Table.class_eval do
+            include Postgresql::Check::Table
+          end
+
+          base::TableDefinition.class_eval do
+            include Postgresql::Check::TableDefinition
+          end
         end
       end
     end


### PR DESCRIPTION
I just updated my app to Rails 4.2 and ran into an issue with postgresql-check. I'm not sure if that's the defacto way of keeping compatibility for multiple versions of Rails in a gem but this works and it's dead simple!

Cheers,
