### PR TITLE
Update ActiveRecord 4.2 internal table @name reference

### DIFF
--- a/lib/postgresql/check/table.rb
+++ b/lib/postgresql/check/table.rb
@@ -2,11 +2,21 @@ module Postgresql
   module Check
     module Table
       def check(condition, options)
-        @base.add_check(@table_name, condition, options)
+        @base.add_check(check_table_name, condition, options)
       end
 
       def remove_check(options)
-        @base.remove_check(@table_name, options)
+        @base.remove_check(check_table_name, options)
+      end
+
+      private
+      # @api private
+      def check_table_name
+        if ActiveRecord::VERSION::STRING > "4.2"
+          @name
+        else
+          @table_name
+        end
       end
     end
   end


### PR DESCRIPTION
This is an other fix for rails 4.2-stable.

Highlight of the change :

[rails-4.2](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L97)

``` ruby
 class Table
      attr_reader :name

      def initialize(table_name, base)
        @name = table_name
        @base = base
      end
```

[rails-4.1](https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L351)

``` ruby
class Table
      def initialize(table_name, base)
        @table_name = table_name
        @base = base
      end
```

cc @jbourassa 
