### PR TITLE
No more adding "<table_name>_" before constraint name. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ end
 You can add a check constraint in your migration:
 
 ```ruby
-add_check :products, 'price > 0', :name => 'price_check'
+add_check :products, 'price > 0', :name => 'products_price_check'
 ```
 
 The code above generates following SQL:
@@ -54,13 +54,12 @@ The code above generates following SQL:
 ALTER TABLE "products" ADD CONSTRAINT "products_price_check" (price > 0)
 ```
 
-**NOTE**: `:name` option is mandatory now. Also note that table name auto-included
-to constraint name.
+**NOTE**: `:name` option is mandatory now.
 
 To remove constraint use `remove_check` method:
 
 ```ruby
-remove_check :products, :name => 'price_check'
+remove_check :products, :name => 'products_price_check'
 ```
 
 ## Change Table methods
@@ -70,7 +69,7 @@ This gem adds extra methods to `create_table` and `change_table`:
 ```ruby
 create_table :products do |t|
   t.decimal :price, :null => false
-  t.check 'price > 0', :name => 'price_check'
+  t.check 'price > 0', :name => 'products_price_check'
 end
 ```
 
@@ -78,7 +77,7 @@ Remove a check constraint:
 
 ```ruby
 change_table :products do |t|
-  t.remove_check :name => 'price_check'
+  t.remove_check :name => 'products_price_check'
 end
 ```
 

--- a/lib/postgresql/check/schema_statements.rb
+++ b/lib/postgresql/check/schema_statements.rb
@@ -27,7 +27,7 @@ module Postgresql
         name = options.fetch(:name) { raise 'add_check, :name option required' }
 
         sql = "ALTER TABLE #{quote_table_name(table_name)} " +
-            "ADD CONSTRAINT #{quote_column_name("#{table_name}_#{name}")} " +
+            "ADD CONSTRAINT #{quote_column_name(name)} " +
             "CHECK (#{condition})"
 
         execute(sql)
@@ -49,7 +49,7 @@ module Postgresql
         name = options.fetch(:name) { raise 'remove_check, :name option required' }
 
         sql = "ALTER TABLE #{quote_table_name(table_name)} " +
-            "DROP CONSTRAINT #{quote_column_name("#{table_name}_#{name}")}"
+            "DROP CONSTRAINT #{quote_column_name(name)}"
 
         execute(sql)
       end


### PR DESCRIPTION
~~The syntax for adding a check is:~~

~~add_check :products, 'price > 0', name: 'check_name'~~

~~Generating `products_check_name` as constraint name.~~

~~But the name of the table were being added again on `schema.rb`:~~

~~add_check :products, 'price > 0', name: 'products_check_name'~~

~~Generating `products_products_check_name` on running `db:schema:load`.~~

---

**Update**

Before:

``` ruby
add_check :products, 'price > 0', name: 'check_name'
```

Now:

``` ruby
add_check :products, 'price > 0', name: 'products_check_name'
```
