### PR TITLE
remove DEPRECATION WARNING: alias_method_chain is deprecated

### DIFF
--- a/lib/postgresql/check/schema_dumper.rb
+++ b/lib/postgresql/check/schema_dumper.rb
@@ -4,7 +4,8 @@ module Postgresql
       extend ActiveSupport::Concern
 
       included do
-        alias_method_chain :table, :checks
+        alias_method :table_without_checks, :table
+        alias_method :table, :table_with_checks
       end
 
       def table_with_checks(table, stream)

--- a/lib/postgresql/check/schema_statements.rb
+++ b/lib/postgresql/check/schema_statements.rb
@@ -4,7 +4,8 @@ module Postgresql
       extend ActiveSupport::Concern
 
       included do
-        alias_method_chain :create_table, :checks
+        alias_method :create_table_without_checks, :create_table
+        alias_method :create_table, :create_table_with_checks
       end
 
       # Add a new Check constraint to table with given +table_name+


### PR DESCRIPTION
remove DEPRECATION WARNING: alias_method_chain is deprecated. according to https://github.com/rails/rails/pull/19434
