### PR TITLE
Improve schema dump

### DIFF
--- a/lib/postgresql/check/schema_dumper.rb
+++ b/lib/postgresql/check/schema_dumper.rb
@@ -27,7 +27,7 @@ module Postgresql
 
       def dump_check_constraint(check)
         <<-RUBY.chomp
-  add_check "#{remove_prefix_and_suffix(check.table_name)}", "#{check.condition}", name: "#{check.name}"
+  add_check "#{remove_prefix_and_suffix(check.table_name)}", "#{check.condition.gsub('"', '\"')}", name: "#{check.name}"
         RUBY
       end
     end

--- a/lib/postgresql/check/schema_statements.rb
+++ b/lib/postgresql/check/schema_statements.rb
@@ -72,7 +72,7 @@ module Postgresql
       # @api private
       def checks(table_name)
         checks_info = select_all <<-SQL
-          SELECT c.conname, c.consrc
+          SELECT DISTINCT c.conname, c.consrc
           FROM pg_constraint c
           INNER JOIN pg_class t
             ON c.conrelid = t.oid


### PR DESCRIPTION
This PR improve the schema dumping by fixing two bugs:

**1 - When gathering checks**
When the check are gathered from the database, they are queried from the `pg_constraint` table, based on the table name. When using multiple postgresql schemas (for example with the gem [Apartment](https://github.com/influitive/apartment)), there will be multiple tables with the same name in different schemas. This was resulting in multiple copies of the same check in the schema dump. For example, with 5 different postgresql schemas, the `schema.rb`would looks like:

```
add_check "alert_zones", "st_isvalid(geom)", name: "enforce_valid_geom"
add_check "alert_zones", "st_isvalid(geom)", name: "enforce_valid_geom"
add_check "alert_zones", "st_isvalid(geom)", name: "enforce_valid_geom"
add_check "alert_zones", "st_isvalid(geom)", name: "enforce_valid_geom"
add_check "alert_zones", "st_isvalid(geom)", name: "enforce_valid_geom"
```

With the `DISTINCT`, we ensure that we only get at most one `check` based on the same column / condition per table, globally.

**2- When dumping column name conditions that could include reserved keywords**
Consider the following check: `t.check 'st_isvalid(position)', name: 'enforce_valid_geom'`. Postgres parser will detect that the _position_ is a reserved keyword and it will quote the check accordingly: `st_isvalid("position")`. The problem is that when dumping the check to the schema, it will looks like this: 
```
add_check "complaints", "st_isvalid("position")", name: "enforce_valid_geom"
```
which is invalid. 

With the escaping of double quote, we ensure that the dumped condition is properly escaped in the `schema.rb`.


